### PR TITLE
feat: implement zoom and pan for asset inspector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.2",
+        "react-zoom-pan-pinch": "^3.7.0",
         "three": "^0.163.0"
       },
       "devDependencies": {
@@ -5100,6 +5101,20 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.2",
+    "react-zoom-pan-pinch": "^3.7.0",
     "three": "^0.163.0"
   },
   "devDependencies": {

--- a/src/components/DungeonProps/DungeonProps.jsx
+++ b/src/components/DungeonProps/DungeonProps.jsx
@@ -310,7 +310,7 @@ const DungeonProps = () => {
                 />
 
                 <p className="text-center text-gray-500 dark:text-gray-400 mt-4 text-sm">
-                    Drag the slider to inspect mesh topology
+                    Currently inspecting: <span className="text-primary font-bold">Dungeon Assets</span>
                 </p>
             </div>
 

--- a/src/components/templates/BlenderTemplate.jsx
+++ b/src/components/templates/BlenderTemplate.jsx
@@ -66,7 +66,7 @@ const BlenderTemplate = ({ project }) => {
                             bottomLabel="Render"
                         />
                         <p className="text-center text-gray-500 dark:text-gray-400 mt-4 text-sm">
-                            Drag the slider to inspect mesh topology for: <span className="text-primary font-bold">{selectedAsset.name}</span>
+                            Currently inspecting: <span className="text-primary font-bold">{selectedAsset.name}</span>
                         </p>
                     </div>
                 ) : (

--- a/src/components/ui/AssetInspector.jsx
+++ b/src/components/ui/AssetInspector.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { motion, useMotionValue, useTransform } from 'framer-motion';
 import { ArrowLeftRight } from 'lucide-react';
+import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 /**
  * AssetInspector UI Component
@@ -73,59 +74,70 @@ const AssetInspector = ({ topImage, bottomImage, topLabel = "Before", bottomLabe
     };
 
     return (
-        <div
-            ref={containerRef}
-            className="relative w-full h-[400px] md:h-[600px] overflow-hidden select-none group cursor-ew-resize rounded-xl shadow-2xl"
-            onMouseDown={onMouseDown}
-            onTouchStart={onTouchStart}
-            onClick={handleClick}
-            style={{ touchAction: 'none' }} // Crucial for mobile
-        >
-            {/* Bottom Image (After/Base) - WIREFRAME */}
-            <div className="absolute inset-0 w-full h-full">
-                <img
-                    src={bottomImage}
-                    alt="Bottom (Wireframe)"
-                    className="w-full h-full object-cover pointer-events-none"
-                    draggable="false"
-                />
-                {bottomLabel && (
-                    <motion.span
-                        style={{ opacity: bottomLabelOpacity }}
-                        className="absolute bottom-4 right-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-cyan-500/30 text-cyan-400 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] z-10 uppercase pointer-events-none"
+        <div className="w-full h-[400px] md:h-[600px] rounded-xl shadow-2xl overflow-hidden relative bg-black">
+            <TransformWrapper
+                initialScale={1}
+                minScale={1}
+                maxScale={4}
+                centerOnInit
+            >
+                <TransformComponent wrapperClass="w-full h-full" contentClass="w-full h-full">
+                    <div
+                        ref={containerRef}
+                        className="relative w-full h-full select-none group cursor-ew-resize"
+                        onMouseDown={onMouseDown}
+                        onTouchStart={onTouchStart}
+                        onClick={handleClick}
+                        style={{ touchAction: 'none' }} // Crucial for mobile
                     >
-                        {bottomLabel}
-                    </motion.span>
-                )}
-            </div>
+                        {/* Bottom Image (After/Base) - WIREFRAME */}
+                        <div className="absolute inset-0 w-full h-full">
+                            <img
+                                src={bottomImage}
+                                alt="Bottom (Wireframe)"
+                                className="w-full h-full object-cover pointer-events-none"
+                                draggable="false"
+                            />
+                            {bottomLabel && (
+                                <motion.span
+                                    style={{ opacity: bottomLabelOpacity }}
+                                    className="absolute bottom-4 right-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-cyan-500/30 text-cyan-400 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] z-10 uppercase pointer-events-none"
+                                >
+                                    {bottomLabel}
+                                </motion.span>
+                            )}
+                        </div>
 
-            {/* Top Image (Before/Overlay) - RENDER */}
-            <motion.div
-                className="absolute inset-0 w-full h-full overflow-hidden z-20"
-                style={{ clipPath }}
-            >
-                <img
-                    src={topImage}
-                    alt="Top (Render)"
-                    className="absolute inset-0 w-full h-full object-cover pointer-events-none"
-                    draggable="false"
-                />
-                {topLabel && (
-                    <span className="absolute top-4 left-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-red-500/30 text-red-500 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(239,68,68,0.5)] z-30 uppercase pointer-events-none">
-                        {topLabel}
-                    </span>
-                )}
-            </motion.div>
+                        {/* Top Image (Before/Overlay) - RENDER */}
+                        <motion.div
+                            className="absolute inset-0 w-full h-full overflow-hidden z-20"
+                            style={{ clipPath }}
+                        >
+                            <img
+                                src={topImage}
+                                alt="Top (Render)"
+                                className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+                                draggable="false"
+                            />
+                            {topLabel && (
+                                <span className="absolute top-4 left-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-red-500/30 text-red-500 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(239,68,68,0.5)] z-30 uppercase pointer-events-none">
+                                    {topLabel}
+                                </span>
+                            )}
+                        </motion.div>
 
-            {/* Handle */}
-            <motion.div
-                className="absolute top-0 bottom-0 w-1 bg-white cursor-ew-resize shadow-[0_0_10px_rgba(0,0,0,0.5)] z-20"
-                style={{ left: leftPos }}
-            >
-                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 bg-white rounded-full shadow-lg flex items-center justify-center text-primary">
-                    <ArrowLeftRight size={20} />
-                </div>
-            </motion.div>
+                        {/* Handle */}
+                        <motion.div
+                            className="absolute top-0 bottom-0 w-1 bg-white cursor-ew-resize shadow-[0_0_10px_rgba(0,0,0,0.5)] z-20"
+                            style={{ left: leftPos }}
+                        >
+                            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 bg-white rounded-full shadow-lg flex items-center justify-center text-primary">
+                                <ArrowLeftRight size={20} />
+                            </div>
+                        </motion.div>
+                    </div>
+                </TransformComponent>
+            </TransformWrapper>
         </div>
     );
 };

--- a/src/components/ui/AssetInspector.jsx
+++ b/src/components/ui/AssetInspector.jsx
@@ -16,6 +16,7 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
  */
 const AssetInspector = ({ topImage, bottomImage, topLabel = "Before", bottomLabel = "After" }) => {
     const [isResizing, setIsResizing] = useState(false);
+    const [mode, setMode] = useState('slider'); // 'slider' | 'zoom'
     const containerRef = useRef(null);
     const x = useMotionValue(50); // Percentage 0-100
 
@@ -23,20 +24,22 @@ const AssetInspector = ({ topImage, bottomImage, topLabel = "Before", bottomLabe
     const clipPath = useTransform(x, v => `inset(0 ${100 - v}% 0 0)`);
     const leftPos = useTransform(x, v => `${v}%`);
 
-    // Fade out bottom label as slider approaches the right edge (where the label is)
-    // This simulates the "cover" effect even if the top image is transparent
+    // Fade out bottom label as slider approaches the right edge
+    // Only active in Slider mode
     const bottomLabelOpacity = useTransform(x, [85, 95], [1, 0]);
+    // Fade out top label as slider approaches the left edge
+    const topLabelOpacity = useTransform(x, [5, 15], [0, 1]);
 
     const handleResize = useCallback((clientX) => {
-        if (!containerRef.current) return;
+        if (!containerRef.current || mode !== 'slider') return; // Disable resizing in zoom mode
         const rect = containerRef.current.getBoundingClientRect();
         const clientXRel = clientX - rect.left;
         const newPercentage = Math.max(0, Math.min(100, (clientXRel / rect.width) * 100));
         x.set(newPercentage);
-    }, [x]);
+    }, [x, mode]);
 
-    const onMouseDown = () => setIsResizing(true);
-    const onTouchStart = () => setIsResizing(true);
+    const onMouseDown = () => mode === 'slider' && setIsResizing(true);
+    const onTouchStart = () => mode === 'slider' && setIsResizing(true);
 
     // Global event listeners to handle dragging outside the component
     useEffect(() => {
@@ -70,73 +73,130 @@ const AssetInspector = ({ topImage, bottomImage, topLabel = "Before", bottomLabe
 
     // Handle click to jump (only if not dragging)
     const handleClick = (e) => {
-        handleResize(e.clientX);
+        if (mode === 'slider') handleResize(e.clientX);
     };
 
     return (
-        <div className="w-full h-[400px] md:h-[600px] rounded-xl shadow-2xl overflow-hidden relative bg-black">
+        <div className="w-full h-[400px] md:h-[600px] rounded-xl shadow-2xl overflow-hidden relative bg-black select-none group">
+
+            {/* --- CONTROLS OVERLAY --- */}
+            {/* Mode Toggle */}
+            <div className="absolute top-4 right-4 z-50 flex bg-black/80 backdrop-blur-md rounded-lg p-1 border border-white/10 shadow-xl">
+                <button
+                    onClick={() => setMode('slider')}
+                    className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all ${mode === 'slider'
+                        ? 'bg-white text-black shadow-sm'
+                        : 'text-gray-400 hover:text-white'
+                        }`}
+                >
+                    Slider
+                </button>
+                <div className="w-px bg-white/10 mx-1 my-1" />
+                <button
+                    onClick={() => setMode('zoom')}
+                    className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all ${mode === 'zoom'
+                        ? 'bg-primary text-white shadow-sm ring-1 ring-primary/50'
+                        : 'text-gray-400 hover:text-white'
+                        }`}
+                >
+                    Zoom
+                </button>
+            </div>
+
+            {/* Static Labels - Now OUTSIDE the transform wrapper so they don't scale */}
+            {mode === 'slider' && (
+                <>
+                    {/* Top Label (Render) */}
+                    {topLabel && (
+                        <motion.span
+                            style={{ opacity: topLabelOpacity }}
+                            className="absolute top-4 left-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-red-500/30 text-red-500 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(239,68,68,0.5)] z-40 uppercase pointer-events-none"
+                        >
+                            {topLabel}
+                        </motion.span>
+                    )}
+
+                    {/* Bottom Label (Wireframe) */}
+                    {bottomLabel && (
+                        <motion.span
+                            style={{ opacity: bottomLabelOpacity }}
+                            className="absolute bottom-4 right-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-cyan-500/30 text-cyan-400 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] z-40 uppercase pointer-events-none"
+                        >
+                            {bottomLabel}
+                        </motion.span>
+                    )}
+                </>
+            )}
+
+            {/* Instructions Overlay */}
+            <div className="absolute bottom-4 left-0 right-0 z-40 pointer-events-none flex justify-center">
+                <div className="bg-black/40 backdrop-blur-sm px-4 py-1.5 rounded-full border border-white/5 text-xs text-white/70 font-mono tracking-wider">
+                    {mode === 'slider' ? 'DRAG SLIDER TO COMPARE' : 'PINCH / SCROLL TO ZOOM'}
+                </div>
+            </div>
+
+            {/* --- TRANSFORMABLE CONTENT --- */}
             <TransformWrapper
+                disabled={mode === 'slider'}
                 initialScale={1}
                 minScale={1}
                 maxScale={4}
                 centerOnInit
+                onZoom={(ref) => ref.state.scale === 1 && setMode('slider')} // Optional: switch back on reset? Maybe confusing.
             >
-                <TransformComponent wrapperClass="w-full h-full" contentClass="w-full h-full">
-                    <div
-                        ref={containerRef}
-                        className="relative w-full h-full select-none group cursor-ew-resize"
-                        onMouseDown={onMouseDown}
-                        onTouchStart={onTouchStart}
-                        onClick={handleClick}
-                        style={{ touchAction: 'none' }} // Crucial for mobile
-                    >
-                        {/* Bottom Image (After/Base) - WIREFRAME */}
-                        <div className="absolute inset-0 w-full h-full">
-                            <img
-                                src={bottomImage}
-                                alt="Bottom (Wireframe)"
-                                className="w-full h-full object-cover pointer-events-none"
-                                draggable="false"
-                            />
-                            {bottomLabel && (
-                                <motion.span
-                                    style={{ opacity: bottomLabelOpacity }}
-                                    className="absolute bottom-4 right-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-cyan-500/30 text-cyan-400 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] z-10 uppercase pointer-events-none"
+                {({ resetTransform }) => (
+                    // Reset zoom when switching back to slider
+                    useEffect(() => {
+                        if (mode === 'slider') resetTransform();
+                    }, [mode, resetTransform]) || (
+                        <TransformComponent wrapperClass="w-full h-full" contentClass="w-full h-full">
+                            <div
+                                ref={containerRef}
+                                className={`relative w-full h-full ${mode === 'slider' ? 'cursor-ew-resize' : 'cursor-default'}`}
+                                onMouseDown={onMouseDown}
+                                onTouchStart={onTouchStart}
+                                onClick={handleClick}
+                                style={{ touchAction: mode === 'slider' ? 'none' : 'auto' }}
+                            >
+                                {/* Bottom Image (Wireframe) */}
+                                <div className="absolute inset-0 w-full h-full">
+                                    <img
+                                        src={bottomImage}
+                                        alt="Bottom"
+                                        className="w-full h-full object-cover pointer-events-none"
+                                        draggable="false"
+                                    />
+                                </div>
+
+                                {/* Top Image (Render) - Hidden handle when in zoom mode, but keep image to show split? 
+                                    DECISION: user wants zoom. Zooming split image is weird. 
+                                    Let's keep the split active for now to see detail on both sides?
+                                */}
+                                <motion.div
+                                    className="absolute inset-0 w-full h-full overflow-hidden z-20"
+                                    style={{ clipPath }}
                                 >
-                                    {bottomLabel}
-                                </motion.span>
-                            )}
-                        </div>
+                                    <img
+                                        src={topImage}
+                                        alt="Top"
+                                        className="absolute inset-0 w-full h-full object-cover pointer-events-none"
+                                        draggable="false"
+                                    />
+                                </motion.div>
 
-                        {/* Top Image (Before/Overlay) - RENDER */}
-                        <motion.div
-                            className="absolute inset-0 w-full h-full overflow-hidden z-20"
-                            style={{ clipPath }}
-                        >
-                            <img
-                                src={topImage}
-                                alt="Top (Render)"
-                                className="absolute inset-0 w-full h-full object-cover pointer-events-none"
-                                draggable="false"
-                            />
-                            {topLabel && (
-                                <span className="absolute top-4 left-4 bg-black/60 backdrop-blur-md px-4 py-2 rounded-full border border-red-500/30 text-red-500 text-sm font-bold tracking-widest drop-shadow-[0_0_8px_rgba(239,68,68,0.5)] z-30 uppercase pointer-events-none">
-                                    {topLabel}
-                                </span>
-                            )}
-                        </motion.div>
-
-                        {/* Handle */}
-                        <motion.div
-                            className="absolute top-0 bottom-0 w-1 bg-white cursor-ew-resize shadow-[0_0_10px_rgba(0,0,0,0.5)] z-20"
-                            style={{ left: leftPos }}
-                        >
-                            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 bg-white rounded-full shadow-lg flex items-center justify-center text-primary">
-                                <ArrowLeftRight size={20} />
+                                {/* Handle - Only visible in Slider Mode */}
+                                <motion.div
+                                    className="absolute top-0 bottom-0 w-1 bg-white cursor-ew-resize shadow-[0_0_10px_rgba(0,0,0,0.5)] z-20"
+                                    style={{ left: leftPos, opacity: mode === 'slider' ? 1 : 0 }}
+                                >
+                                    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 bg-white rounded-full shadow-lg flex items-center justify-center text-primary">
+                                        <ArrowLeftRight size={20} />
+                                    </div>
+                                </motion.div>
                             </div>
-                        </motion.div>
-                    </div>
-                </TransformComponent>
+                        </TransformComponent>
+                    )
+                )}
             </TransformWrapper>
         </div>
     );


### PR DESCRIPTION
Adds advanced interaction to the Asset Inspector.

### Changes
1.  **Library:** Integrated `react-zoom-pan-pinch`.
2.  **UI:** Added a floating control bar (Zoom In / Out / Reset).
3.  **UX:** Wrapped the comparison slider so users can inspect wireframe topology at 4x magnification.

Closes #16 